### PR TITLE
Resolve time.clock problem

### DIFF
--- a/filter_plugins/jasypt.py
+++ b/filter_plugins/jasypt.py
@@ -1,6 +1,12 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+# https://github.com/fareliner/jasypt4py/issues/3#issuecomment-1058722911
+# Resolve time.clock problem
+import time
+time.clock = time.time
+
+
 from ansible.errors import AnsibleError
 
 try:


### PR DESCRIPTION
The function time.clock() has been removed, after having been deprecated since Python 3.3. In order to continue using the filter, a workaround is added.